### PR TITLE
feat: encode Decimal::NaN larger than +Infinity

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -546,7 +546,6 @@ impl<B: Buf> Deserializer<B> {
         // decode exponent
         let flag = self.input.get_u8();
         let exponent = match flag {
-            0x06 => return Ok(Decimal::NaN),
             0x07 => return Ok(Decimal::NegInf),
             0x08 => !self.input.get_u8() as i8,
             0x09..=0x13 => (0x13 - flag) as i8,
@@ -556,6 +555,7 @@ impl<B: Buf> Deserializer<B> {
             0x17..=0x21 => (flag - 0x17) as i8,
             0x22 => self.input.get_u8() as i8,
             0x23 => return Ok(Decimal::Inf),
+            0x24 => return Ok(Decimal::NaN),
             b => return Err(Error::InvalidDecimalEncoding(b)),
         };
         // decode mantissa
@@ -760,7 +760,6 @@ mod tests {
         // Notice: decimals like 100.00 will be decoding as 100.
 
         let decimals = [
-            "nan",
             "-inf",
             "-123456789012345678901234",
             "-1234567890.1234",
@@ -775,6 +774,7 @@ mod tests {
             "41721.900909090909090909090909",
             "123456789012345678901234",
             "inf",
+            "nan",
         ];
         let mut last_encoding = vec![];
         for s in decimals {

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -20,14 +20,14 @@ use std::str::FromStr;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(docsrs, doc(cfg(feature = "decimal")))]
 pub enum Decimal {
-    /// Not a Number.
-    NaN,
     /// Negative infinity.
     NegInf,
     /// Normalized value.
     Normalized(rust_decimal::Decimal),
     /// Infinity.
     Inf,
+    /// Not a Number.
+    NaN,
 }
 
 impl Decimal {


### PR DESCRIPTION
By default, PostgreSQL treats +Infinity < NaN < Null, while SQLite treats Null < NaN < -Infinity.

This crate does not handle `null`. For `f32` and `f64`, it treats `NaN` as larger than `Infinity`; but for `decimal`, it treats `NaN` as smaller than `-Infinity`.

This PR changes the ordering behavior of `decimal` to also treat `NaN` as larger than `Infinity`.

Note that IEEE 754 does define a [total ordering](https://doc.rust-lang.org/std/primitive.f32.html#method.total_cmp), where `NaN` with a negative sign is smaller than `-Infinity`, and `NaN` without sign bit set is larger than `+Infinity`. It also defines `-0` to be smaller than `0`. This crate is already making the encoding of all `NaN`s to be the same, and `-0` = `0`. It is not a goal to follow that total ordering definition. (Or we could impl the standard here, and require the caller side to handle these values before encoding.)