### PR TITLE
release: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2023-05-16
+
+### Changed
+
+- `Decimal::NaN` is now encoded as larger than `+Infinity`.
+
 ## [0.1.1] - 2023-04-12
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memcomparable"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "A memcomparable serialization format."
 homepage = "https://github.com/risingwavelabs/memcomparable"


### PR DESCRIPTION
The new encoding for `Decimal::NaN` is not a compatible change.